### PR TITLE
Allow list_remote() to work with list of servers. Currently only returning values from first available URL.

### DIFF
--- a/refgenconf/refgenconf.py
+++ b/refgenconf/refgenconf.py
@@ -393,10 +393,11 @@ class RefGenConf(yacman.YacAttMap):
             names for sort
         :return str, str: text reps of remotely available genomes and assets
         """
-        url = get_url(self[CFG_SERVERS_KEY], API_ID_ASSETS)
-        _LOGGER.info("Querying available assets from server: {}".format(url))
-        genomes, assets = _list_remote(url, genome, order)
-        return genomes, assets
+        for server in self[CFG_SERVERS_KEY]:
+            url = get_url(server, API_ID_ASSETS)
+            _LOGGER.info("Querying available assets from server: {}".format(url))
+            genomes, assets = _list_remote(url, genome, order)
+            return genomes, assets
 
     def tag_asset(self, genome, asset, tag, new_tag):
         """

--- a/tests/test_list_remote.py
+++ b/tests/test_list_remote.py
@@ -13,7 +13,7 @@ def test_list_remote(rgc, tmpdir):
     new_rgc = RefGenConf(entries={CFG_FOLDER_KEY: tmpdir.strpath,
                           CFG_SERVERS_KEY: DEFAULT_SERVER,
                           CFG_GENOMES_KEY: rgc[CFG_GENOMES_KEY]})
-    new_rgc[CFG_SERVERS_KEY] = "http://staging.refgenomes.databio.org"
+    new_rgc[CFG_SERVERS_KEY] = ["http://staging.refgenomes.databio.org"]
     print("NEW RGC KEYS: {}".format(list(new_rgc.keys())))
     with mock.patch("refgenconf.refgenconf._read_remote_data",
                     return_value=rgc.genomes):


### PR DESCRIPTION
Not entirely clear how should merge strings from different servers together.